### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -739,7 +739,7 @@ static int laue2m(int axes[3],
 static int lauemmm(int axes[3],
 		   SPGCONST PointSymmetry * pointsym)
 {
-  int i, count, axis, tmpval;
+  int i, count, axis;
   int prop_rot[3][3];
 
 
@@ -1024,7 +1024,7 @@ static int laue3m(int axes[3],
 static int lauem3m(int axes[3],
 		   SPGCONST PointSymmetry * pointsym)
 {
-  int i, count, axis, tmpval;
+  int i, count, axis;
   int prop_rot[3][3];
 
   for (i = 0; i < 3; i++) { axes[i] = -1; }

--- a/src/spg_database.c
+++ b/src/spg_database.c
@@ -8575,7 +8575,7 @@ SpacegroupType spgdb_get_spacegroup_type(const int hall_number)
 
   spgtype.number = 0;
   
-  if (0 < hall_number || hall_number < 531) {
+  if (0 < hall_number && hall_number < 531) {
     spgtype = spacegroup_types[hall_number];
   } else {
     spgtype = spacegroup_types[0];


### PR DESCRIPTION
[src/spg_database.c:8578]: (warning) Logical disjunction always evaluates to true: hall_number > 0 || hall_number < 531.
[src/pointgroup.c:742]: (style) Unused variable: tmpval
[src/pointgroup.c:1027]: (style) Unused variable: tmpval