### PR TITLE
Fix void * arith on MSVC

### DIFF
--- a/src/overlap.h
+++ b/src/overlap.h
@@ -37,6 +37,7 @@
 
 /* Contains pre-allocated memory and precomputed data for check_total_overlap. */
 typedef struct {
+  /* Number of atoms. */
   int size;
 
   /* Pre-allocated memory for various things. */


### PR DESCRIPTION
I compiled with `-Wpedantic` this time to make sure there were no GCC extensions accidentally being used.

cc @jochym, can you test this?  I don't have access to a computer with MSVC...