### PR TITLE
Adding missing metadata to use_setuptools==False branch of setup.py.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -144,7 +144,10 @@ if use_setuptools:
 else:
     setup(name='spglib',
           version=version,
+          license='BSD-3-Clause',
           description='This is the spglib module.',
+          long_description=open('README.rst', 'rb').read().decode('utf-8'),
+          long_description_content_type='text/x-rst',
           author='Atsushi Togo',
           author_email='atz.togo@gmail.com',
           url='http://atztogo.github.io/spglib/',


### PR DESCRIPTION
There are two branches of the control flow and I assume that both of them should be as similar as possible.