### PR TITLE
Fix python tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ install:
 
 script:
 - if [[ "$DOCKER_DEPLOY" == "false" ]]; then
-    cd python/test;
-    python -m unittest discover -b;
-    cd ../..;
+    cd python;
+    python setup.py test;
+    cd ..;
   else
     cd python;
     cp -a ../src .;

--- a/python/setup.py
+++ b/python/setup.py
@@ -140,7 +140,9 @@ if use_setuptools:
           install_requires=['numpy'],
           provides=['spglib'],
           platforms=['all'],
-          ext_modules=[extension])
+          ext_modules=[extension],
+          test_suite='nose.collector',
+          tests_require=['nose'])
 else:
     setup(name='spglib',
           version=version,
@@ -152,4 +154,6 @@ else:
           requires=['numpy'],
           provides=['spglib'],
           platforms=['all'],
-          ext_modules=[extension])
+          ext_modules=[extension],
+          test_suite='nose.collector',
+          tests_require=['nose'])

--- a/python/test/test_hall_number_from_symmetry.py
+++ b/python/test/test_hall_number_from_symmetry.py
@@ -11,7 +11,7 @@ class TestGetHallNumberFromSymmetry(unittest.TestCase):
         self._filenames = []
         for d in dirnames:
             self._filenames += ["%s/%s" % (d, fname)
-                                for fname in listdir("./data/%s" % d)]
+                                for fname in listdir("./test/data/%s" % d)]
 
     def tearDown(self):
         pass
@@ -19,7 +19,7 @@ class TestGetHallNumberFromSymmetry(unittest.TestCase):
     def test_get_hall_number_from_symmetry(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 dataset = get_symmetry_dataset(cell, symprec=1e-1)
                 hall_number = get_hall_number_from_symmetry(

--- a/python/test/test_niggli_delaunay.py
+++ b/python/test/test_niggli_delaunay.py
@@ -18,9 +18,9 @@ def get_angles(lattice):
 
 class TestNiggliDelaunay(unittest.TestCase):
     def setUp(self):
-        self._input_lattices = self._read_file("lattices.dat")
-        self._niggli_lattices = self._read_file("niggli_lattices.dat")
-        self._delaunay_lattices = self._read_file("delaunay_lattices.dat")
+        self._input_lattices = self._read_file("test/lattices.dat")
+        self._niggli_lattices = self._read_file("test/niggli_lattices.dat")
+        self._delaunay_lattices = self._read_file("test/delaunay_lattices.dat")
 
     def tearDown(self):
         pass

--- a/python/test/test_reciprocal_mesh.py
+++ b/python/test/test_reciprocal_mesh.py
@@ -243,7 +243,7 @@ class TestReciprocalMesh(unittest.TestCase):
                          ["hexagonal/POSCAR-182", [4, 4, 2]])
         i = 0
         for fname, mesh in file_and_mesh:
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             ir_rec_mesh = get_ir_reciprocal_mesh(mesh, cell)
             (mapping_table, grid_address) = ir_rec_mesh
             # for gp, ga in zip(mapping_table, grid_address):
@@ -259,7 +259,7 @@ class TestReciprocalMesh(unittest.TestCase):
                          ["hexagonal/POSCAR-182", [4, 4, 2]])
         i = 0
         for fname, mesh in file_and_mesh:
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             rotations = get_symmetry_dataset(cell)['rotations']
             ir_rec_mesh = get_stabilized_reciprocal_mesh(mesh, rotations)
             (mapping_table, grid_address) = ir_rec_mesh
@@ -274,7 +274,7 @@ class TestReciprocalMesh(unittest.TestCase):
         i = 0
         for is_shift in ([0, 0, 0], [0, 1, 0]):
             for fname, mesh in file_and_mesh:
-                cell = read_vasp("./data/%s" % fname)
+                cell = read_vasp("./test/data/%s" % fname)
                 ir_rec_mesh = get_ir_reciprocal_mesh(mesh, cell,
                                                      is_shift=is_shift)
                 (mapping_table, grid_address) = ir_rec_mesh

--- a/python/test/test_spglib.py
+++ b/python/test/test_spglib.py
@@ -46,7 +46,7 @@ class TestSpglib(unittest.TestCase):
         self._filenames = []
         for d in dirnames:
             self._filenames += ["%s/%s" % (d, fname)
-                                for fname in listdir("./data/%s" % d)]
+                                for fname in listdir("./test/data/%s" % d)]
 
     def tearDown(self):
         pass
@@ -54,7 +54,7 @@ class TestSpglib(unittest.TestCase):
     def test_get_symmetry_dataset(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
 
             if 'distorted' in fname:
                 symprec = 1e-1
@@ -82,7 +82,7 @@ class TestSpglib(unittest.TestCase):
     def test_standardize_cell(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 std_cell = standardize_cell(cell,
                                             to_primitive=False,
@@ -101,7 +101,7 @@ class TestSpglib(unittest.TestCase):
     def test_standardize_cell_from_primitive(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 prim_cell = standardize_cell(cell,
                                              to_primitive=True,
@@ -128,7 +128,7 @@ class TestSpglib(unittest.TestCase):
     def test_standardize_cell_to_primitive(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 prim_cell = standardize_cell(cell,
                                              to_primitive=True,
@@ -147,7 +147,7 @@ class TestSpglib(unittest.TestCase):
     def test_refine_cell(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 dataset_orig = get_symmetry_dataset(cell, symprec=1e-1)
             else:
@@ -162,7 +162,7 @@ class TestSpglib(unittest.TestCase):
     def test_find_primitive(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 dataset = get_symmetry_dataset(cell, symprec=1e-1)
                 primitive = find_primitive(cell, symprec=1e-1)
@@ -190,7 +190,7 @@ class TestSpglib(unittest.TestCase):
     def test_get_symmetry(self):
         for fname in self._filenames:
             spgnum = int(fname.split('-')[1])
-            cell = read_vasp("./data/%s" % fname)
+            cell = read_vasp("./test/data/%s" % fname)
             if 'distorted' in fname:
                 num_sym_dataset = len(
                     get_symmetry_dataset(cell, symprec=1e-1)['rotations'])


### PR DESCRIPTION
Testing in Python is usually done via ``python setup.py test``. To enable this for spglib, the test suite has to be defined in setup.py and filesystem paths in tests have to be made relative to setup.py location. This PR contains both fixes. On my machine (Ubuntu 16) all tests for both Python2 and Python3 pass now via ``python{,3} setup.py test``.