### PR TITLE
fix memory leak of site_symmetry_symbol members

### DIFF
--- a/src/refinement.c
+++ b/src/refinement.c
@@ -301,6 +301,10 @@ void ref_free_exact_structure(ExactStructure *exstr)
       free(exstr->std_mapping_to_primitive);
       exstr->std_mapping_to_primitive = NULL;
     }
+    if (exstr->site_symmetry_symbols != NULL) {
+      free(exstr->site_symmetry_symbols);
+      exstr->site_symmetry_symbols = NULL;
+    }
     free(exstr);
   }
 }

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -357,6 +357,11 @@ void spg_free_dataset(SpglibDataset *dataset)
     dataset->n_std_atoms = 0;
   }
 
+  if (dataset->site_symmetry_symbols != NULL) {
+    free(dataset->site_symmetry_symbols);
+    dataset->site_symmetry_symbols = NULL;
+  }
+
   dataset->spacegroup_number = 0;
   dataset->hall_number = 0;
   strcpy(dataset->international_symbol, "");


### PR DESCRIPTION
Our CI for CP2K discovered a number of memory leaks in the latest spglib version which are fixed with the patch in this PR.

The report from the LeakSanitizer before the fix:
```
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
/workspace/cp2k/regtesting/local/sdbg/TEST-local-sdbg-2019-02-01_12-54-35/DFTB/regtest-nonscc/si_kp2.inp.out
    #10 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #11 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #12 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f9c5f23bd68 in __interceptor_malloc /opt/cp2k-toolchain/build/gcc-8.2.0/libsanitizer/lsan/lsan_interceptors.cc:52
    #1 0x7f9c6028959c in ref_get_exact_structure_and_symmetry /opt/cp2k-toolchain/build/spglib-1.12.1/src/refinement.c:204
    #2 0x7f9c602811b1 in det_determine_all /opt/cp2k-toolchain/build/spglib-1.12.1/src/determination.c:76
    #3 0x7f9c6028d4aa in get_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1202
    #4 0x7f9c6028e69a in get_multiplicity /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1621
    #5 0x7f9c6028e69a in spg_get_multiplicity /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:500
    #6 0x138f1a4 in __cryssym_MOD_crys_sym_gen /workspace/cp2k/src/cryssym.F:178
    #7 0xeec3e9 in __kpoint_methods_MOD_kpoint_initialize /workspace/cp2k/src/kpoint_methods.F:169
    #8 0xfc5edc in __qs_environment_MOD_qs_init /workspace/cp2k/src/qs_environment.F:334
    #9 0xe22275 in __f77_interface_MOD_create_force_env /workspace/cp2k/src/f77_interface.F:790
    #10 0x40cc9a in cp2k_run /workspace/cp2k/src/start/cp2k_runs.F:282
    #11 0x40dc9b in __cp2k_runs_MOD_run_input /workspace/cp2k/src/start/cp2k_runs.F:1111
    #12 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #13 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #14 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f9c5f23bd68 in __interceptor_malloc /opt/cp2k-toolchain/build/gcc-8.2.0/libsanitizer/lsan/lsan_interceptors.cc:52
    #1 0x7f9c6028959c in ref_get_exact_structure_and_symmetry /opt/cp2k-toolchain/build/spglib-1.12.1/src/refinement.c:204
    #2 0x7f9c602811b1 in det_determine_all /opt/cp2k-toolchain/build/spglib-1.12.1/src/determination.c:76
    #3 0x7f9c6028d4aa in get_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1202
    #4 0x7f9c6028e033 in get_international /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1961
    #5 0x138ee56 in __cryssym_MOD_crys_sym_gen /workspace/cp2k/src/cryssym.F:173
    #6 0xeec3e9 in __kpoint_methods_MOD_kpoint_initialize /workspace/cp2k/src/kpoint_methods.F:169
    #7 0xfc5edc in __qs_environment_MOD_qs_init /workspace/cp2k/src/qs_environment.F:334
    #8 0xe22275 in __f77_interface_MOD_create_force_env /workspace/cp2k/src/f77_interface.F:790
    #9 0x40cc9a in cp2k_run /workspace/cp2k/src/start/cp2k_runs.F:282
    #10 0x40dc9b in __cp2k_runs_MOD_run_input /workspace/cp2k/src/start/cp2k_runs.F:1111
    #11 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #12 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #13 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f9c5f23bd68 in __interceptor_malloc /opt/cp2k-toolchain/build/gcc-8.2.0/libsanitizer/lsan/lsan_interceptors.cc:52
    #1 0x7f9c6028d656 in set_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1335
    #2 0x7f9c6028d656 in get_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1207
    #3 0x7f9c6028dccc in get_symmetry_from_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1466
    #4 0x138f593 in __cryssym_MOD_crys_sym_gen /workspace/cp2k/src/cryssym.F:182
    #5 0xeec3e9 in __kpoint_methods_MOD_kpoint_initialize /workspace/cp2k/src/kpoint_methods.F:169
    #6 0xfc5edc in __qs_environment_MOD_qs_init /workspace/cp2k/src/qs_environment.F:334
    #7 0xe22275 in __f77_interface_MOD_create_force_env /workspace/cp2k/src/f77_interface.F:790
    #8 0x40cc9a in cp2k_run /workspace/cp2k/src/start/cp2k_runs.F:282
    #9 0x40dc9b in __cp2k_runs_MOD_run_input /workspace/cp2k/src/start/cp2k_runs.F:1111
    #10 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #11 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #12 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f9c5f23bd68 in __interceptor_malloc /opt/cp2k-toolchain/build/gcc-8.2.0/libsanitizer/lsan/lsan_interceptors.cc:52
    #1 0x7f9c6028d656 in set_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1335
    #2 0x7f9c6028d656 in get_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1207
    #3 0x7f9c6028ea15 in get_schoenflies /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:2004
    #4 0x138f7ea in __cryssym_MOD_crys_sym_gen /workspace/cp2k/src/cryssym.F:185
    #5 0xeec3e9 in __kpoint_methods_MOD_kpoint_initialize /workspace/cp2k/src/kpoint_methods.F:169
    #6 0xfc5edc in __qs_environment_MOD_qs_init /workspace/cp2k/src/qs_environment.F:334
    #7 0xe22275 in __f77_interface_MOD_create_force_env /workspace/cp2k/src/f77_interface.F:790
    #8 0x40cc9a in cp2k_run /workspace/cp2k/src/start/cp2k_runs.F:282
    #9 0x40dc9b in __cp2k_runs_MOD_run_input /workspace/cp2k/src/start/cp2k_runs.F:1111
    #10 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #11 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #12 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f9c5f23bd68 in __interceptor_malloc /opt/cp2k-toolchain/build/gcc-8.2.0/libsanitizer/lsan/lsan_interceptors.cc:52
    #1 0x7f9c6028959c in ref_get_exact_structure_and_symmetry /opt/cp2k-toolchain/build/spglib-1.12.1/src/refinement.c:204
    #2 0x7f9c602811b1 in det_determine_all /opt/cp2k-toolchain/build/spglib-1.12.1/src/determination.c:76
    #3 0x7f9c6028d4aa in get_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1202
    #4 0x7f9c6028dccc in get_symmetry_from_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1466
    #5 0x138f593 in __cryssym_MOD_crys_sym_gen /workspace/cp2k/src/cryssym.F:182
    #6 0xeec3e9 in __kpoint_methods_MOD_kpoint_initialize /workspace/cp2k/src/kpoint_methods.F:169
    #7 0xfc5edc in __qs_environment_MOD_qs_init /workspace/cp2k/src/qs_environment.F:334
    #8 0xe22275 in __f77_interface_MOD_create_force_env /workspace/cp2k/src/f77_interface.F:790
    #9 0x40cc9a in cp2k_run /workspace/cp2k/src/start/cp2k_runs.F:282
    #10 0x40dc9b in __cp2k_runs_MOD_run_input /workspace/cp2k/src/start/cp2k_runs.F:1111
    #11 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #12 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #13 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f9c5f23bd68 in __interceptor_malloc /opt/cp2k-toolchain/build/gcc-8.2.0/libsanitizer/lsan/lsan_interceptors.cc:52
    #1 0x7f9c6028959c in ref_get_exact_structure_and_symmetry /opt/cp2k-toolchain/build/spglib-1.12.1/src/refinement.c:204
    #2 0x7f9c602811b1 in det_determine_all /opt/cp2k-toolchain/build/spglib-1.12.1/src/determination.c:76
    #3 0x7f9c6028d4aa in get_dataset /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:1202
    #4 0x7f9c6028ea15 in get_schoenflies /opt/cp2k-toolchain/build/spglib-1.12.1/src/spglib.c:2004
    #5 0x138f7ea in __cryssym_MOD_crys_sym_gen /workspace/cp2k/src/cryssym.F:185
    #6 0xeec3e9 in __kpoint_methods_MOD_kpoint_initialize /workspace/cp2k/src/kpoint_methods.F:169
    #7 0xfc5edc in __qs_environment_MOD_qs_init /workspace/cp2k/src/qs_environment.F:334
    #8 0xe22275 in __f77_interface_MOD_create_force_env /workspace/cp2k/src/f77_interface.F:790
    #9 0x40cc9a in cp2k_run /workspace/cp2k/src/start/cp2k_runs.F:282
    #10 0x40dc9b in __cp2k_runs_MOD_run_input /workspace/cp2k/src/start/cp2k_runs.F:1111
    #11 0x40948b in cp2k /workspace/cp2k/src/start/cp2k.F:281
    #12 0x409595 in main /workspace/cp2k/src/start/cp2k.F:45
    #13 0x7f9c5da4cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: LeakSanitizer: 448 byte(s) leaked in 8 allocation(s).
EXIT CODE:  23  MEANING:  RUNTIME FAIL
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```