### PR TITLE
Changed strcpy() calls to strncpy() to avoid buffer overflows

### DIFF
--- a/src/arithmetic.c
+++ b/src/arithmetic.c
@@ -150,7 +150,7 @@ int arth_get_symbol(char symbol[7], const int spgroup_number)
   }
 
   arth_number = arithmetic_crystal_classes[spgroup_number];
-  strcpy(symbol, arithmetic_crystal_class_symbols[arth_number]);
+  strncpy(symbol, arithmetic_crystal_class_symbols[arth_number], sizeof symbol - 1);
   for (i = 0; i < 6; i++) {
     if (symbol[i] == ' ') {symbol[i] = '\0';}
   }

--- a/src/pointgroup.c
+++ b/src/pointgroup.c
@@ -460,8 +460,8 @@ Pointgroup ptg_get_pointgroup(const int pointgroup_number)
 
   pointgroup.number = pointgroup_number;
   pointgroup_type = pointgroup_data[pointgroup_number];
-  strcpy(pointgroup.symbol, pointgroup_type.symbol);
-  strcpy(pointgroup.schoenflies, pointgroup_type.schoenflies);
+  strncpy(pointgroup.symbol, pointgroup_type.symbol, sizeof pointgroup.symbol - 1);
+  strncpy(pointgroup.schoenflies, pointgroup_type.schoenflies, sizeof pointgroup.schoenflies - 1);
   for (i = 0; i < 5; i++) {
     if (pointgroup.symbol[i] == ' ') {pointgroup.symbol[i] = '\0';}
   }

--- a/src/spacegroup.c
+++ b/src/spacegroup.c
@@ -662,13 +662,13 @@ static Spacegroup * get_spacegroup(const int hall_number,
     spacegroup->number = spacegroup_type.number;
     spacegroup->hall_number = hall_number;
     spacegroup->pointgroup_number = spacegroup_type.pointgroup_number;
-    strcpy(spacegroup->schoenflies, spacegroup_type.schoenflies);
-    strcpy(spacegroup->hall_symbol, spacegroup_type.hall_symbol);
-    strcpy(spacegroup->international, spacegroup_type.international);
-    strcpy(spacegroup->international_long, spacegroup_type.international_full);
-    strcpy(spacegroup->international_short,
-           spacegroup_type.international_short);
-    strcpy(spacegroup->choice, spacegroup_type.choice);
+    strncpy(spacegroup->schoenflies, spacegroup_type.schoenflies, sizeof spacegroup->schoenflies - 1);
+    strncpy(spacegroup->hall_symbol, spacegroup_type.hall_symbol, sizeof spacegroup->hall_symbol - 1);
+    strncpy(spacegroup->international, spacegroup_type.international, sizeof spacegroup->international - 1);
+    strncpy(spacegroup->international_long, spacegroup_type.international_full, sizeof spacegroup->international_long - 1);
+    strncpy(spacegroup->international_short,
+           spacegroup_type.international_short, sizeof spacegroup->international_short - 1);
+    strncpy(spacegroup->choice, spacegroup_type.choice, sizeof spacegroup->choice - 1);
   }
 
   return spacegroup;

--- a/src/spglib.c
+++ b/src/spglib.c
@@ -627,7 +627,7 @@ int spg_get_pointgroup(char symbol[6],
     return 0;
   }
 
-  strcpy(symbol, pointgroup.symbol);
+  strncpy(symbol, pointgroup.symbol, sizeof symbol-1);
 
   spglib_error_code = SPGLIB_SUCCESS;
   return pointgroup.number;
@@ -688,18 +688,18 @@ SpglibSpacegroupType spg_get_spacegroup_type(const int hall_number)
   if (0 < hall_number && hall_number < 531) {
     spgtype = spgdb_get_spacegroup_type(hall_number);
     spglibtype.number = spgtype.number;
-    strcpy(spglibtype.schoenflies, spgtype.schoenflies);
-    strcpy(spglibtype.hall_symbol, spgtype.hall_symbol);
-    strcpy(spglibtype.choice, spgtype.choice);
-    strcpy(spglibtype.international, spgtype.international);
-    strcpy(spglibtype.international_full, spgtype.international_full);
-    strcpy(spglibtype.international_short, spgtype.international_short);
+    strncpy(spglibtype.schoenflies, spgtype.schoenflies, sizeof spglibtype.schoenflies - 1);
+    strncpy(spglibtype.hall_symbol, spgtype.hall_symbol, sizeof spglibtype.hall_symbol - 1);
+    strncpy(spglibtype.choice, spgtype.choice, sizeof spglibtype.choice - 1);
+    strncpy(spglibtype.international, spgtype.international, sizeof spglibtype.international - 1);
+    strncpy(spglibtype.international_full, spgtype.international_full, sizeof spglibtype.international_full - 1);
+    strncpy(spglibtype.international_short, spgtype.international_short, sizeof spglibtype.international_short - 1);
     pointgroup = ptg_get_pointgroup(spgtype.pointgroup_number);
-    strcpy(spglibtype.pointgroup_international, pointgroup.symbol);
-    strcpy(spglibtype.pointgroup_schoenflies, pointgroup.schoenflies);
+    strncpy(spglibtype.pointgroup_international, pointgroup.symbol, sizeof spglibtype.pointgroup_international - 1);
+    strncpy(spglibtype.pointgroup_schoenflies, pointgroup.schoenflies, sizeof spglibtype.pointgroup_schoenflies - 1);
     arth_number = arth_get_symbol(arth_symbol, spgtype.number);
     spglibtype.arithmetic_crystal_class_number = arth_number;
-    strcpy(spglibtype.arithmetic_crystal_class_symbol, arth_symbol);
+    strncpy(spglibtype.arithmetic_crystal_class_symbol, arth_symbol, sizeof spglibtype.arithmetic_crystal_class_symbol - 1);
     spglib_error_code = SPGLIB_SUCCESS;
   } else {
     spglib_error_code = SPGERR_SPACEGROUP_SEARCH_FAILED;
@@ -1222,9 +1222,9 @@ static int set_dataset(SpglibDataset * dataset,
   dataset->n_atoms = cell->size;
   dataset->spacegroup_number = spacegroup->number;
   dataset->hall_number = spacegroup->hall_number;
-  strcpy(dataset->international_symbol, spacegroup->international_short);
-  strcpy(dataset->hall_symbol, spacegroup->hall_symbol);
-  strcpy(dataset->choice, spacegroup->choice);
+  strncpy(dataset->international_symbol, spacegroup->international_short, sizeof dataset->international_symbol-1);
+  strncpy(dataset->hall_symbol, spacegroup->hall_symbol, sizeof dataset->hall_symbol - 1);
+  strncpy(dataset->choice, spacegroup->choice, sizeof dataset->choice - 1);
   mat_inverse_matrix_d3(inv_lat, spacegroup->bravais_lattice, 0);
   mat_multiply_matrix_d3(dataset->transformation_matrix,
                          inv_lat, cell->lattice);
@@ -1332,7 +1332,7 @@ static int set_dataset(SpglibDataset * dataset,
 
   /* dataset->pointgroup_number = spacegroup->pointgroup_number; */
   pointgroup = ptg_get_pointgroup(spacegroup->pointgroup_number);
-  strcpy(dataset->pointgroup_symbol, pointgroup.symbol);
+  strncpy(dataset->pointgroup_symbol, pointgroup.symbol, sizeof dataset->pointgroup_symbol - 1);
 
   return 1;
 
@@ -1897,7 +1897,7 @@ static int get_international(char symbol[11],
 
   if (dataset->spacegroup_number > 0) {
     number = dataset->spacegroup_number;
-    strcpy(symbol, dataset->international_symbol);
+    strncpy(symbol, dataset->international_symbol, sizeof symbol - 1);
     spg_free_dataset(dataset);
     dataset = NULL;
   } else {
@@ -1941,7 +1941,7 @@ static int get_schoenflies(char symbol[7],
   if (dataset->spacegroup_number > 0) {
     number = dataset->spacegroup_number;
     spgtype = spg_get_spacegroup_type(dataset->hall_number);
-    strcpy(symbol, spgtype.schoenflies);
+    strncpy(symbol, spgtype.schoenflies, sizeof symbol - 1);
     spg_free_dataset(dataset);
     dataset = NULL;
   } else {


### PR DESCRIPTION
Dear Atsushi,

This patch fixes a bug which caused a crash within the Fortran interface of CASTEP, and which causes the spglib test "make check" to fail.  The "strcpy" calls were in some instances overrunning the output buffer and causing mamory corruption.  The fix is to change to "strncpy".

Keith Refson