### PR TITLE
Fix missing libm in target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES ${PROJECT_SOURCE_DIR}/src/arithmetic.c
 
 # Shared library
 add_library(symspg SHARED ${SOURCES})
+target_link_libraries(symspg m)
 set_property(TARGET symspg PROPERTY VERSION ${serial})
 set_property(TARGET symspg PROPERTY SOVERSION ${soserial})
 install(TARGETS symspg LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Linking with --no-undefined linker flag fails otherwise, as e.g.
`sqrt` is not defined.

Fixes issue #84.