### PR TITLE
'check' target on msvc  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,6 @@ add_custom_target(check
         COMMAND ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1
             ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --verbose
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    DEPENDS ALL_BUILD
+    DEPENDS spglibtest
     )
 
-add_dependencies(check spglibtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,17 +70,26 @@ install(TARGETS symspg_static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 # Header file
 install(FILES ${PROJECT_SOURCE_DIR}/src/spglib.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-# make check
-enable_testing()
-
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-
-set(CMAKE_CTEST_COMMAND ctest -V)
-
 add_executable(spglibtest EXCLUDE_FROM_ALL ${PROJECT_SOURCE_DIR}/src/test.c ${SOURCES})
 
 if(NOT MSVC)
   target_link_libraries(spglibtest m)
 endif()
+
+enable_testing()
 add_test(spglibtest spglibtest)
+
+# make check
+
+# cf. https://stackoverflow.com/questions/5709914/using-cmake-how-do-i-get-verbose-output-from-ctest
+add_custom_target(check 
+        ${CMAKE_COMMAND} -E echo CWD=${CMAKE_BINARY_DIR}
+        COMMAND ${CMAKE_COMMAND} -E echo CMD=${CMAKE_CTEST_COMMAND} -C $<CONFIG>
+        COMMAND ${CMAKE_COMMAND} -E echo ----------------------------------
+        COMMAND ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1
+            ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --verbose
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    DEPENDS ALL_BUILD
+    )
+
 add_dependencies(check spglibtest)


### PR DESCRIPTION
make the 'check' target output verbose/work on msvc
 